### PR TITLE
Add support for the alternative drop syntax

### DIFF
--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -77,7 +77,7 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.groups = stairsplus:prepare_groups(fields.groups)
 		def.description = desc
-		if fields.drop then
+		if fields.drop and not type(fields.drop) == "table" then
 			def.drop = modname.. ":micro_" ..fields.drop..alternate
 		end
 		minetest.register_node(":" ..modname.. ":micro_" ..subname..alternate, def)

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -77,7 +77,7 @@ function stairsplus:register_panel(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		if fields.drop then
+		if fields.drop and not type(fields.drop) == "table" then
 			def.drop = modname.. ":panel_" ..fields.drop..alternate
 		end
 		minetest.register_node(":" ..modname.. ":panel_" ..subname..alternate, def)

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -48,7 +48,7 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = ("%s (%d/16)"):format(desc_base, num)
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		if fields.drop then
+		if fields.drop and not type(fields.drop) == "table" then
 			def.drop = modname.. ":slab_" .. fields.drop .. alternate
 		end
 		minetest.register_node(":" .. modname .. ":slab_" .. subname .. alternate, def)

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -231,7 +231,7 @@ function stairsplus:register_slope(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		if fields.drop then
+		if fields.drop and not type(fields.drop) == "table" then
 			def.drop = modname.. ":slope_" ..fields.drop..alternate
 		end
 		minetest.register_node(":" ..modname.. ":slope_" ..subname..alternate, def)

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -117,7 +117,7 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		if fields.drop then
+		if fields.drop and not type(fields.drop) == "table" then
 			def.drop = modname .. ":stair_" .. fields.drop .. alternate
 		end
 		minetest.register_node(":" .. modname .. ":stair_" .. subname .. alternate, def)


### PR DESCRIPTION
Until now, when the moreblocks node for a node with the [alternative drop syntax](https://github.com/minetest/minetest/blob/master/doc/lua_api.txt#L3574) were registered, the game crashed.

@sofar Maybe you can merge this soon, as it is a quite trivial bugfix.