### PR TITLE
allow passing paramtype2 to the nodes being created

### DIFF
--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -88,7 +88,7 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 		end
 		def.drawtype = "nodebox"
 		def.paramtype = "light"
-		def.paramtype2 = "facedir"
+		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.groups = stairsplus:prepare_groups(fields.groups)
 		def.description = desc

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -88,7 +88,7 @@ function stairsplus:register_panel(modname, subname, recipeitem, fields)
 		end
 		def.drawtype = "nodebox"
 		def.paramtype = "light"
-		def.paramtype2 = "facedir"
+		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -59,7 +59,7 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 		end
 		def.drawtype = "nodebox"
 		def.paramtype = "light"
-		def.paramtype2 = "facedir"
+		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.description = ("%s (%d/16)"):format(desc_base, num)
 		def.groups = stairsplus:prepare_groups(fields.groups)

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -242,7 +242,7 @@ function stairsplus:register_slope(modname, subname, recipeitem, fields)
 		end
 		def.drawtype = "mesh"
 		def.paramtype = "light"
-		def.paramtype2 = "facedir"
+		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -128,7 +128,7 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 		end
 		def.drawtype = "nodebox"
 		def.paramtype = "light"
-		def.paramtype2 = "facedir"
+		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)


### PR DESCRIPTION
Title says it all.  To be used for when a mod using stairsplus needs `paramtype2 = "colorfacedir"` or whatever.