### PR TITLE
Build a list of all of the shapes created by stairsplus

### DIFF
--- a/stairsplus/init.lua
+++ b/stairsplus/init.lua
@@ -12,6 +12,8 @@ local modpath = minetest.get_modpath("moreblocks").. "/stairsplus"
 stairsplus = {}
 stairsplus.expect_infinite_stacks = false
 
+stairsplus.shapes_list = {}
+
 if not minetest.get_modpath("unified_inventory")
 and minetest.setting_getbool("creative_mode") then
 	stairsplus.expect_infinite_stacks = true

--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -65,6 +65,10 @@ local microblocks_defs = {
 	}
 }
 
+for k,v in pairs(microblocks_defs) do
+	table.insert(stairsplus.shapes_list, { "micro_", k })
+end
+
 function stairsplus:register_micro_alias(modname_old, subname_old, modname_new, subname_new)
 	local defs = stairsplus.copytable(microblocks_defs)
 	for alternate, def in pairs(defs) do

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -65,6 +65,10 @@ local panels_defs = {
 	}
 }
 
+for k,v in pairs(panels_defs) do
+	table.insert(stairsplus.shapes_list, { "panel_", k })
+end
+
 function stairsplus:register_panel_alias(modname_old, subname_old, modname_new, subname_new)
 	local defs = stairsplus.copytable(panels_defs)
 	for alternate, def in pairs(defs) do

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -44,6 +44,10 @@ local slabs_defs = {
 					}
 }
 
+for k,v in pairs(slabs_defs) do
+	table.insert(stairsplus.shapes_list, { "slab_", k })
+end
+
 function stairsplus:register_slab_alias(modname_old, subname_old, modname_new, subname_new)
 	local defs = stairsplus.copytable(slabs_defs)
 	for alternate, def in pairs(defs) do

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -219,6 +219,10 @@ local slopes_defs = {
 	},
 }
 
+for k,v in pairs(slopes_defs) do
+	table.insert(stairsplus.shapes_list, { "slope_", k })
+end
+
 function stairsplus:register_slope_alias(modname_old, subname_old, modname_new, subname_new)
 	local defs = stairsplus.copytable(slopes_defs)
 	for alternate, def in pairs(defs) do

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -105,6 +105,10 @@ local stairs_defs = {
 	},
 }
 
+for k,v in pairs(stairs_defs) do
+	table.insert(stairsplus.shapes_list, { "stair_", k })
+end
+
 function stairsplus:register_stair_alias(modname_old, subname_old, modname_new, subname_new)
 	local defs = stairsplus.copytable(stairs_defs)
 	for alternate, def in pairs(defs) do


### PR DESCRIPTION
Needed so that other mods can reference the list of shapes and perhaps remove some that don't fit, or to un-register nodes when a mod needs to replace something in moreblocks/stairsplus.