### PR TITLE
add shape_type and base_material attributes to item definition

### DIFF
--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -95,8 +95,7 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		def.base_material = recipeitem
-		def.shape_type = "micro"
+		def.groups.micro = 1
 		def.description = desc
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname.. ":micro_" ..fields.drop..alternate

--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -95,6 +95,8 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.groups = stairsplus:prepare_groups(fields.groups)
+		def.base_material = recipeitem
+		def.shape_type = "micro"
 		def.description = desc
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname.. ":micro_" ..fields.drop..alternate

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -96,6 +96,8 @@ function stairsplus:register_panel(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
+		def.base_material = recipeitem
+		def.shape_type = "panel"
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname.. ":panel_" ..fields.drop..alternate
 		end

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -96,8 +96,7 @@ function stairsplus:register_panel(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		def.base_material = recipeitem
-		def.shape_type = "panel"
+		def.groups.panel = 1
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname.. ":panel_" ..fields.drop..alternate
 		end

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -96,8 +96,7 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		def.base_material = recipeitem
-		def.shape_type = "slab"
+		def.groups.slab = 1
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname.. ":slab_" .. fields.drop .. alternate
 		end

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -96,6 +96,8 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 		def.paramtype2 = def.paramtype2 or "facedir"
 		def.on_place = minetest.rotate_node
 		def.groups = stairsplus:prepare_groups(fields.groups)
+		def.base_material = recipeitem
+		def.shape_type = "slab"
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname.. ":slab_" .. fields.drop .. alternate
 		end

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -250,6 +250,8 @@ function stairsplus:register_slope(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
+		def.base_material = recipeitem
+		def.shape_type = "slope"
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname.. ":slope_" ..fields.drop..alternate
 		end

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -250,8 +250,7 @@ function stairsplus:register_slope(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		def.base_material = recipeitem
-		def.shape_type = "slope"
+		def.groups.slope = 1
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname.. ":slope_" ..fields.drop..alternate
 		end

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -136,8 +136,7 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
-		def.base_material = recipeitem
-		def.shape_type = "stair"
+		def.groups.stair = 1
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname .. ":stair_" .. fields.drop .. alternate
 		end

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -136,6 +136,8 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 		def.on_place = minetest.rotate_node
 		def.description = desc
 		def.groups = stairsplus:prepare_groups(fields.groups)
+		def.base_material = recipeitem
+		def.shape_type = "stair"
 		if fields.drop and not (type(fields.drop) == "table") then
 			def.drop = modname .. ":stair_" .. fields.drop .. alternate
 		end


### PR DESCRIPTION
The information about the parentage of shaped nodes can be useful after the init stage. This PR adds the attributes shape_type and base_material to node/item definition to get this info available for other mods.
This change is primary for smart_inventory. If active the "not_in_creative_inventory" is ignored and the shaped items are available in a separate "shaped" group for easy access.
The change is generic enough for more use cases. I do not know the background of issue #70 but I think it is solvable by this change too.
Why I do not use the stairsplus.shapes_list? They are more mods that generates shaped things. See carpets or ts_doors as example. I prefer to implement a generic way for all instead of the "dependency hell".