### PR TITLE
Replace deprecated methods

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -8,7 +8,7 @@ Licensed under the zlib license. See LICENSE.md for more information.
 moreblocks.config = {}
 
 local function getbool_default(setting, default)
-	local value = minetest.setting_getbool(setting)
+	local value = minetest.settings:get_bool(setting)
 	if value == nil then
 		value = default
 	end
@@ -21,7 +21,7 @@ local function setting(settingtype, name, default)
 			getbool_default("moreblocks." .. name, default)
 	else
 		moreblocks.config[name] =
-			minetest.setting_get("moreblocks." .. name) or default
+			minetest.settings:get("moreblocks." .. name) or default
 	end
 end
 

--- a/crafting.lua
+++ b/crafting.lua
@@ -454,7 +454,7 @@ minetest.register_craft({
 	}
 })
 
-if minetest.setting_getbool("moreblocks.circular_saw_crafting") ~= false then -- “If nil or true then”
+if minetest.settings:get_bool("moreblocks.circular_saw_crafting") ~= false then -- “If nil or true then”
 	minetest.register_craft({
 		output = "moreblocks:circular_saw",
 		recipe = {

--- a/init.lua
+++ b/init.lua
@@ -28,6 +28,6 @@ dofile(modpath .. "/redefinitions.lua")
 dofile(modpath .. "/crafting.lua")
 dofile(modpath .. "/aliases.lua")
 
-if minetest.setting_getbool("log_mods") then
+if minetest.settings:get_bool("log_mods") then
 	minetest.log("action", S("[moreblocks] loaded."))
 end

--- a/stairsplus/init.lua
+++ b/stairsplus/init.lua
@@ -15,7 +15,7 @@ stairsplus.expect_infinite_stacks = false
 stairsplus.shapes_list = {}
 
 if not minetest.get_modpath("unified_inventory")
-and minetest.setting_getbool("creative_mode") then
+and minetest.settings:get_bool("creative_mode") then
 	stairsplus.expect_infinite_stacks = true
 end
 


### PR DESCRIPTION
- 'setting_get' with 'settings:get'
- 'setting_getbool' with 'settings:get_bool'

May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267