### PR TITLE
Replace deprecated function 'intllib.Getter'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,11 @@ moreblocks = {}
 
 local S
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		S = intllib.make_gettext_pair()
+	else
+		S = intllib.Getter()
+	end
 else
 	S = function(s) return s end
 end

--- a/init.lua
+++ b/init.lua
@@ -11,7 +11,7 @@ Licensed under the zlib license. See LICENSE.md for more information.
 moreblocks = {}
 
 local S
-if minetest.get_modpath("intllib") then
+if minetest.global_exists("intllib") then
 	S = intllib.Getter()
 else
 	S = function(s) return s end


### PR DESCRIPTION
- Check first for *intllib.make_gettext_pair*, otherwise continue using
deprecated function *intllib.Getter*
- Call *minetest.global_exists* in place of *minetest.get_modpath* for *intllib* check (better practice in my opionion)