### PR TITLE
Allow conversion of all shapes to microblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- All Stairs+ nodes can be now converted into microblocks
+
 ## [1.1.0] - 2017-10-04
 
 ### Added
@@ -26,7 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Tin Block
   - Wool (all colors)
 - Other mods can now get a list of all the defined Stairs+ shapes
-- All Stairs+ nodes can be now converted into microblocks
 
 ## [1.0.0] - 2017-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Tin Block
   - Wool (all colors)
 - Other mods can now get a list of all the defined Stairs+ shapes
+- All Stairs+ nodes can be now converted into microblocks
 
 ## [1.0.0] - 2017-02-19
 

--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -154,4 +154,40 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 		output = recipeitem,
 		recipe = {modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname},
 	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":micro_" .. subname .. "_1"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":micro_" .. subname .. "_2"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":micro_" .. subname .. "_4"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 2",
+		recipe =  {modname .. ":micro_" .. subname .. "_12"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 2",
+		recipe =  {modname .. ":micro_" .. subname .. "_14"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 2",
+		recipe =  {modname .. ":micro_" .. subname .. "_15"},
+	})
 end

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -134,4 +134,40 @@ function stairsplus:register_panel(modname, subname, recipeitem, fields)
 		output = recipeitem,
 		recipe = {modname .. ":panel_" .. subname, modname .. ":panel_" .. subname, modname .. ":panel_" .. subname, modname .. ":panel_" .. subname},
 	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":panel_" .. subname .. "_1"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":panel_" .. subname .. "_2"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":panel_" .. subname .. "_4"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 3",
+		recipe =  {modname .. ":panel_" .. subname .. "_12"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 4",
+		recipe =  {modname .. ":panel_" .. subname .. "_14"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 4",
+		recipe =  {modname .. ":panel_" .. subname .. "_15"},
+	})
 end

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -254,4 +254,58 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 			output = modname .. ":slab_" .. subname .. " 3",
 			recipe = {modname .. ":stair_" .. subname, modname .. ":stair_" .. subname},
 		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe =  {modname .. ":slab_" .. subname .. "_two_sides"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe =  {modname .. ":slab_" .. subname .. "_three_sides"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe =  {modname .. ":slab_" .. subname .. "_three_sides_u"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe =  {modname .. ":slab_" .. subname .. "_1"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 1",
+			recipe =  {modname .. ":slab_" .. subname .. "_2"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 2",
+			recipe =  {modname .. ":slab_" .. subname .. "_quarter"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 6",
+			recipe =  {modname .. ":slab_" .. subname .. "_three_quarter"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 7",
+			recipe =  {modname .. ":slab_" .. subname .. "_14"},
+		})
+		
+		minetest.register_craft({
+			type = "shapeless",
+			output = modname .. ":micro_" .. subname .. " 8",
+			recipe =  {modname .. ":slab_" .. subname .. "_15"},
+		})
 end

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -363,4 +363,100 @@ function stairsplus:register_slope(modname, subname, recipeitem, fields)
 		output = modname .. ":slope_" .. subname .. "_inner_cut_half_raised",
 		recipe =  {modname .. ":slab_" .. subname, modname .. ":slope_" .. subname .. "_inner_cut_half"},
 	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 4",
+		recipe =  {modname .. ":slope_" .. subname},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 2",
+		recipe =  {modname .. ":slope_" .. subname .. "_half"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 6",
+		recipe =  {modname .. ":slope_" .. subname .. "_half_raised"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 7",
+		recipe =  {modname .. ":slope_" .. subname .. "_inner"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 3",
+		recipe =  {modname .. ":slope_" .. subname .. "_inner_half"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 7",
+		recipe =  {modname .. ":slope_" .. subname .. "_inner_half_raised"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 7",
+		recipe =  {modname .. ":slope_" .. subname .. "_inner_cut"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 4",
+		recipe =  {modname .. ":slope_" .. subname .. "_inner_cut_half"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 8",
+		recipe =  {modname .. ":slope_" .. subname .. "_inner_cut_half_raised"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 3",
+		recipe =  {modname .. ":slope_" .. subname .. "_outer"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 2",
+		recipe =  {modname .. ":slope_" .. subname .. "_outer_half"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 6",
+		recipe =  {modname .. ":slope_" .. subname .. "_outer_half_raised"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 2",
+		recipe =  {modname .. ":slope_" .. subname .. "_outer_cut"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":slope_" .. subname .. "_outer_cut_half"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 3",
+		recipe =  {modname .. ":slope_" .. subname .. "_outer_cut_half_raised"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 4",
+		recipe =  {modname .. ":slope_" .. subname .. "_cut"},
+	})
 end

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -240,4 +240,22 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 			{modname .. ":panel_" .. subname, ""},
 		},
 	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":stair_" .. subname .. "_alt_1"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 1",
+		recipe =  {modname .. ":stair_" .. subname .. "_alt_2"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 2",
+		recipe =  {modname .. ":stair_" .. subname .. "_alt_4"},
+	})
 end


### PR DESCRIPTION
I have always been annoyed how it is impossible to get back full blocks if you attempt to craft some of the more "wild" shapes and I usually end up trashing them.

While it isn't the most logical, this at least ensures there will be no wastage and allow a fix for accidental craftings.
The amount of microblocks received is the same as the cost for crafting it in circular saw.