### PR TITLE
Convert node cut by Xdecor

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,4 @@
+#
+
+moreblocks.circular_saw_crafting			(If false desactive a craft the circular saw)				bool true
+moreblocks.conversion_xdecor>moreblocks		(Convert all block cutting by xdecor) 						bool false

--- a/stairsplus/init.lua
+++ b/stairsplus/init.lua
@@ -49,6 +49,28 @@ function stairsplus:prepare_groups(groups)
 	return result
 end
 
+function stairsplus:uppercase_index_string(words)
+	return string.gsub(
+		string.gsub(
+			minetest.serialize(
+				string.find(
+					words,"%u"
+				)
+			),
+			"return ", "_"
+		),
+		",", "_"
+	)
+end
+
+function stairsplus:normal_alias_or_force(force)
+	if force then
+		return minetest.register_alias_force
+	else
+		return minetest.register_alias
+	end
+end
+
 function stairsplus:register_all(modname, subname, recipeitem, fields)
 	self:register_stair(modname, subname, recipeitem, fields)
 	self:register_slab (modname, subname, recipeitem, fields)
@@ -71,6 +93,12 @@ function stairsplus:register_alias_force_all(modname_old, subname_old, modname_n
 	self:register_slope_alias_force(modname_old, subname_old, modname_new, subname_new)
 	self:register_panel_alias_force(modname_old, subname_old, modname_new, subname_new)
 	self:register_micro_alias_force(modname_old, subname_old, modname_new, subname_new)
+end
+function stairsplus:register_xdecor_alias_all(modname_old, subname_old, modname_new, subname_new, force)
+	self:register_stairs_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
+	self:register_slabs_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
+	self:register_panels_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
+	self:register_micro_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
 end
 
 function register_stair_slab_panel_micro(modname, subname, recipeitem, groups, images, description, drop, light)

--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -69,18 +69,46 @@ for k,v in pairs(microblocks_defs) do
 	table.insert(stairsplus.shapes_list, { "micro_", k })
 end
 
-function stairsplus:register_micro_alias(modname_old, subname_old, modname_new, subname_new)
+function stairsplus:register_micro_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
+	if not(minetest.settings:get_bool("moreblocks.conversion_xdecor>moreblocks")) then
+		return
+	end
+	minetest.register_lbm({
+		name = ":replace_xdecor_mano_cube_" .. modname_old .. "_" .. string.lower(subname_old) .. "_" .. stairsplus:uppercase_index_string(subname_old) .. "_" .. 
+			modname_new .."_" .. string.lower(subname_new) .. stairsplus:uppercase_index_string(subname_new) .. string.gsub(minetest.serialize(force),"return ", "_"),
+		nodenames = {modname_old .. ":" .. subname_old .. "_nanoslab", modname_old .. ":" .. subname_old .."_cube"},
+		run_at_every_load = false,
+		action = function(pos, node)
+			if modname_old .. ":" .. subname_old .. "_nanoslab" == node.name then
+				nodename = modname_new .. ":micro_" .. subname_new .. "_1"
+			else
+				nodename = modname_new .. ":micro_" .. subname_new
+			end
+			if node.param2 == 0 or node.param2%4 == 0 then
+				minetest.set_node(pos, {name = nodename, param2 = node.param2+3})
+			else
+				minetest.set_node(pos, {name = nodename, param2 = node.param2-1})
+			end
+		end,
+	})
+end
+
+function register_micro_alias_and_force(modname_old, subname_old, modname_new, subname_new, force)
+	local stairsplus_alias = stairsplus:normal_alias_or_force(force)
 	local defs = stairsplus.copytable(microblocks_defs)
 	for alternate, def in pairs(defs) do
-		minetest.register_alias(modname_old .. ":micro_" .. subname_old .. alternate, modname_new .. ":micro_" .. subname_new .. alternate)
+		stairsplus_alias(modname_old .. ":micro_" .. subname_old .. alternate, modname_new .. ":micro_" .. subname_new .. alternate)
 	end
+	stairsplus:register_micro_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
+	
+end
+
+function stairsplus:register_micro_alias(modname_old, subname_old, modname_new, subname_new)
+	register_micro_alias_and_force(modname_old, subname_old, modname_new, subname_new, false)
 end
 
 function stairsplus:register_micro_alias_force(modname_old, subname_old, modname_new, subname_new)
-	local defs = stairsplus.copytable(microblocks_defs)
-	for alternate, def in pairs(defs) do
-		minetest.register_alias_force(modname_old .. ":micro_" .. subname_old .. alternate, modname_new .. ":micro_" .. subname_new .. alternate)
-	end
+	register_micro_alias_and_force(modname_old, subname_old, modname_new, subname_new, true)
 end
 
 function stairsplus:register_micro(modname, subname, recipeitem, fields)
@@ -102,6 +130,7 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 		minetest.register_node(":" ..modname.. ":micro_" ..subname..alternate, def)
 	end
 	minetest.register_alias(modname.. ":micro_" ..subname.. "_bottom", modname.. ":micro_" ..subname)
+	stairsplus:register_micro_xdecor_alias(modname, subname, modname, subname, false)
 
 	circular_saw.known_nodes[recipeitem] = {modname, subname}
 

--- a/stairsplus/registrations.lua
+++ b/stairsplus/registrations.lua
@@ -6,63 +6,58 @@ Licensed under the zlib license. See LICENSE.md for more information.
 --]]
 
 local default_nodes = { -- Default stairs/slabs/panels/microblocks:
-	"stone",
-	"stone_block",
-	"cobble",
-	"mossycobble",
-	"brick",
-	"sandstone",
-	"steelblock",
-	"goldblock",
-	"copperblock",
-	"bronzeblock",
-	"diamondblock",
-	"tinblock",
-	"desert_stone",
-	"desert_stone_block",
-	"desert_cobble",
-	"meselamp",
-	"glass",
-	"tree",
-	"wood",
-	"jungletree",
-	"junglewood",
-	"pine_tree",
-	"pine_wood",
-	"acacia_tree",
-	"acacia_wood",
-	"aspen_tree",
-	"aspen_wood",
-	"obsidian",
-	"obsidian_block",
-	"obsidianbrick",
-	"obsidian_glass",
-	"stonebrick",
-	"desert_stonebrick",
-	"sandstonebrick",
-	"silver_sandstone",
-	"silver_sandstone_brick",
-	"silver_sandstone_block",
-	"desert_sandstone",
-	"desert_sandstone_brick",
-	"desert_sandstone_block",
-	"sandstone_block",
-	"coral_skeleton",
+	"default:stone",
+	"default:stone_block",
+	"default:cobble",
+	"default:mossycobble",
+	"default:brick",
+	"default:sandstone",
+	"default:steelblock",
+	"default:goldblock",
+	"default:copperblock",
+	"default:bronzeblock",
+	"default:diamondblock",
+	"default:tinblock",
+	"default:desert_stone",
+	"default:desert_stone_block",
+	"default:desert_cobble",
+	"default:meselamp",
+	"default:glass",
+	"default:tree",
+	"default:wood",
+	"default:jungletree",
+	"default:junglewood",
+	"default:pine_tree",
+	"default:pine_wood",
+	"default:acacia_tree",
+	"default:acacia_wood",
+	"default:aspen_tree",
+	"default:aspen_wood",
+	"default:obsidian",
+	"default:obsidian_block",
+	"default:obsidianbrick",
+	"default:obsidian_glass",
+	"default:stonebrick",
+	"default:desert_stonebrick",
+	"default:sandstonebrick",
+	"default:silver_sandstone",
+	"default:silver_sandstone_brick",
+	"default:silver_sandstone_block",
+	"default:desert_sandstone",
+	"default:desert_sandstone_brick",
+	"default:desert_sandstone_block",
+	"default:sandstone_block",
+	"default:coral_skeleton",
 	"farming:straw"
 }
 
-for _, name in pairs(default_nodes) do
-	local nodename = "default:"..name
-	local a,b = string.find(name, ":")
-	if b then
-		nodename = name
-		name = string.sub(name, b+1)
-	end
+for _, nodename in pairs(default_nodes) do	
+	local mod, name = nodename:match("(.*):(.*)")
 	local ndef = minetest.registered_nodes[nodename]
 	if ndef then
 		local drop
 		if type(ndef.drop) == "string" then
-			drop = ndef.drop:sub((b or 8)+1)
+			drop = ndef.drop:sub(mod:len()+2)
 		end
 
 		local tiles = ndef.tiles
@@ -79,6 +74,7 @@ for _, name in pairs(default_nodes) do
 			sunlight_propagates = true,
 			light_source = ndef.light_source
 		})
+		stairsplus:register_xdecor_alias_all(mod, name, "moreblocks", name, false)
 	end
 end
 

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -48,18 +48,30 @@ for k,v in pairs(slabs_defs) do
 	table.insert(stairsplus.shapes_list, { "slab_", k })
 end
 
-function stairsplus:register_slab_alias(modname_old, subname_old, modname_new, subname_new)
+function stairsplus:register_slabs_xdecor_alias(modname_old, subname_old, modname_new, subname_new)
+	if not(minetest.settings:get_bool("moreblocks.conversion_xdecor>moreblocks")) then
+		return
+	end
+	local stairsplus_alias = stairsplus:normal_alias_or_force(force)
+	stairsplus_alias(modname_old .. ":" .. subname_old .."_microslab", modname_new .. ":slab_" .. subname_new .. "_1")
+end
+
+function register_slab_alias_and_force(modname_old, subname_old, modname_new, subname_new, force)
+	local stairsplus_alias = stairsplus:normal_alias_or_force(force)
 	local defs = stairsplus.copytable(slabs_defs)
 	for alternate, def in pairs(defs) do
-		minetest.register_alias(modname_old .. ":slab_" .. subname_old .. alternate, modname_new .. ":slab_" .. subname_new .. alternate)
+		stairsplus_alias(modname_old .. ":slab_" .. subname_old .. alternate, modname_new .. ":slab_" .. subname_new .. alternate)
 	end
+	stairsplus:register_slabs_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
+end
+
+function stairsplus:register_slab_alias(modname_old, subname_old, modname_new, subname_new)
+	register_slab_alias_and_force(modname_old, subname_old, modname_new, subname_new, false)
+	minetest.register_alias("stairs:slab_" .. subname_old, modname_new .. ":slab_" .. subname_new)
 end
 
 function stairsplus:register_slab_alias_force(modname_old, subname_old, modname_new, subname_new)
-	local defs = stairsplus.copytable(slabs_defs)
-	for alternate, def in pairs(defs) do
-		minetest.register_alias_force(modname_old .. ":slab_" .. subname_old .. alternate, modname_new .. ":slab_" .. subname_new .. alternate)
-	end
+	register_slab_alias_and_force(modname_old, subname_old, modname_new, subname_new, true)
 end
 
 function stairsplus:register_slab(modname, subname, recipeitem, fields)
@@ -102,6 +114,7 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 		minetest.register_node(":" .. modname .. ":slab_" .. subname .. alternate, def)
 	end
 	minetest.register_alias("stairs:slab_" .. subname, modname .. ":slab_" .. subname)
+	stairsplus:register_slabs_xdecor_alias(modname, subname, modname, subname, false)
 
 	circular_saw.known_nodes[recipeitem] = {modname, subname}
 

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -109,18 +109,34 @@ for k,v in pairs(stairs_defs) do
 	table.insert(stairsplus.shapes_list, { "stair_", k })
 end
 
-function stairsplus:register_stair_alias(modname_old, subname_old, modname_new, subname_new)
-	local defs = stairsplus.copytable(stairs_defs)
-	for alternate, def in pairs(defs) do
-		minetest.register_alias(modname_old .. ":stair_" .. subname_old .. alternate, modname_new .. ":stair_" .. subname_new .. alternate)
+function stairsplus:register_stairs_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
+	if not(minetest.settings:get_bool("moreblocks.conversion_xdecor>moreblocks")) then
+		return
 	end
+	local stairsplus_alias = stairsplus:normal_alias_or_force(force)
+	stairsplus_alias(modname_old .. ":" .. subname_old .."_thinstair", modname_new .. ":stair_" ..subname_new .. "_alt_1")
+	stairsplus_alias(modname_old .. ":" .. subname_old .."_doublepanel", modname_new .. ":stair_" ..subname_new .. "_alt")
+	stairsplus_alias(modname_old .. ":" .. subname_old .."_halfstair", modname_new .. ":stair_" ..subname_new .. "_half")
+	stairsplus_alias(modname_old .. ":" .. subname_old .."_outerstair", modname_new .. ":stair_" ..subname_new .. "_outer")
+	stairsplus_alias(modname_old .. ":" .. subname_old .."_innerstair", modname_new .. ":stair_" ..subname_new .. "_inner")
 end
 
-function stairsplus:register_stair_alias_force(modname_old, subname_old, modname_new, subname_new)
+function register_stair_alias_and_force(modname_old, subname_old, modname_new, subname_new, force)
+	local stairsplus_alias = stairsplus:normal_alias_or_force(force)
 	local defs = stairsplus.copytable(stairs_defs)
 	for alternate, def in pairs(defs) do
-		minetest.register_alias_force(modname_old .. ":stair_" .. subname_old .. alternate, modname_new .. ":stair_" .. subname_new .. alternate)
+		stairsplus_alias(modname_old .. ":stair_" .. subname_old .. alternate, modname_new .. ":stair_" .. subname_new .. alternate)
 	end
+	stairsplus:register_stairs_xdecor_alias(modname_old, subname_old, modname_new, subname_new, force)
+end
+
+function stairsplus:register_stair_alias(modname_old, subname_old, modname_new, subname_new)
+	register_stair_alias_and_force(modname_old, subname_old, modname_new, subname_new, false)
+end
+
+
+function stairsplus:register_stair_alias_force(modname_old, subname_old, modname_new, subname_new)
+	register_stair_alias_and_force(modname_old, subname_old, modname_new, subname_new, true)
 end
 
 function stairsplus:register_stair(modname, subname, recipeitem, fields)
@@ -142,6 +158,7 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 		minetest.register_node(":" .. modname .. ":stair_" .. subname .. alternate, def)
 	end
 	minetest.register_alias("stairs:stair_" .. subname, modname .. ":stair_" .. subname)
+	stairsplus:register_stairs_xdecor_alias(modname, subname, modname, subname, false)
 
 	circular_saw.known_nodes[recipeitem] = {modname, subname}
 


### PR DESCRIPTION
Registrations
  -Simplify and add alias for xdecor

Micreoblocks, panels, slabs, stairs
  -Simplify for forcing alias or normal
  -Add function for convert block xdecor
  -Add alias in register.

Init
  function
     uppercase
      calculate the number of capital letters for lbm name
    normal_alias_or_force
      ....
  Add function for alll alias Xdecor

Add Settingtypes