### PR TITLE
Improve drop name extraction logic.

### DIFF
--- a/stairsplus/registrations.lua
+++ b/stairsplus/registrations.lua
@@ -62,7 +62,7 @@ for _, name in pairs(default_nodes) do
 	if ndef then
 		local drop
 		if type(ndef.drop) == "string" then
-			drop = ndef.drop:sub((b or 8)+1)
+			drop = ndef.drop:gsub('.+:', '')
 		end
 
 		local tiles = ndef.tiles


### PR DESCRIPTION
This one line deletes characters up to and including the last colon wherever that may be.