### PR TITLE
Fix saw left-over naming bug.

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -181,7 +181,7 @@ function circular_saw:update_inventory(pos, amount)
 
 	-- 0-7 microblocks may remain left-over:
 	inv:set_list("micro", {
-		modname .. ":micro_" .. material .. "_bottom " .. (amount % 8)
+		modname .. ":micro_" .. material .. " " .. (amount % 8)
 	})
 	-- Display:
 	inv:set_list("output",


### PR DESCRIPTION
The appended '_bottom' is left over from an older naming convention and relies
on an alias to avoid unknown nodes showing up in the saw's left-over bin.