### PR TITLE
Fix slab descriptions.

### DIFF
--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -66,29 +66,24 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 	local defs = stairsplus.copytable(slabs_defs)
 	local desc_base = S("%s Slab"):format(fields.description)
 	for alternate, shape in pairs(defs) do
-
 		local def = {}
-
-		if type(shape) ~= "table" then
-			def = {
-					node_box = {
-						type = "fixed",
-						fixed = {-0.5, -0.5, -0.5, 0.5, (shape/16)-0.5, 0.5},
-					},
-					description = ("%s (%d/16)"):format(desc_base, shape)
-				}
-		else
-			def = {
-				node_box = {
-					type = "fixed",
-					fixed = shape,
-				},
-				description = desc_base
-			}
-		end
-
 		for k, v in pairs(fields) do
 			def[k] = v
+		end
+		if type(shape) ~= "table" then
+			def.node_box = {
+						type = "fixed",
+						fixed = {-0.5, -0.5, -0.5, 0.5, (shape/16)-0.5, 0.5},
+					}
+			def.description = ("%s (%d/16)"):format(desc_base, shape)
+		else
+			def.node_box = {
+					type = "fixed",
+					fixed = shape,
+				}
+			local desc_x = alternate:gsub("_", " ")
+			desc_x = desc_x:gsub("(%a)(%S*)", function(a, b) return a:upper() .. b end)
+			def.description = desc_base .. desc_x
 		end
 
 		def.drawtype = "nodebox"


### PR DESCRIPTION
A regression caused the description of slabs to revert to the source block's description.  This commit fixes the regression and adds descriptions which were missing for the recently added slabs (two_sides, three_sides, and three_sides_u).

Closes minetest-mods/moreblocks#96