### PR TITLE
Drop paramtype2 from glass before registering.

### DIFF
--- a/stairsplus/registrations.lua
+++ b/stairsplus/registrations.lua
@@ -62,9 +62,10 @@ for _, name in pairs(default_nodes) do
 		ndef.drop = ndef.drop:gsub(".+:", "")
 	end
 
-	-- Use the primary tile for all sides of cut glasslike nodes.
+	-- Use the primary tile for all sides of cut glasslike nodes and disregard paramtype2.
 	if #ndef.tiles > 1 and ndef.drawtype and ndef.drawtype:find("glass") then
 		ndef.tiles = {ndef.tiles[1]}
+		ndef.paramtype2 = nil
 	end
 
 	stairsplus:register_all("moreblocks", name, nodename, ndef)


### PR DESCRIPTION
Fix minetest-mods/moreblocks#98

Caused by cf1b054a998a67b06e97c2e022537bf8516abdfb, 6a996eb86ae447a156bcae53a1b23b62ca5d5bb9 and minetest/minetest_game@2f46103ff8fc6f0e9bf2cf6dc507ccc5f4fb6ea8.

For some unknown reason `default:glass` and `obsidian:glass` have `paramtype2 = "glasslikeliquidlevel"`.  After the refactor of `stairsplus/registrations.lua`, all of the source node's defs are passed along to `stairsplus:register_all()`.  Prior to cf1b054a998a67b06e97c2e022537bf8516abdfb the paramtype2 setting was discarded.