### PR TITLE
Stop assuming stair and slab aliases are required.

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,5 @@
 default
 intllib?
+stairs?
 farming?
 wool?

--- a/stairsplus/registrations.lua
+++ b/stairsplus/registrations.lua
@@ -67,7 +67,10 @@ for _, name in pairs(default_nodes) do
 		ndef.tiles = {ndef.tiles[1]}
 	end
 
-	stairsplus:register_all("moreblocks", name, nodename, ndef)
+	mod = "moreblocks"
+	stairsplus:register_all(mod, name, nodename, ndef)
+	minetest.register_alias_force("stairs:stair_" .. name, mod .. ":stair_" .. name)
+	minetest.register_alias_force("stairs:slab_"  .. name, mod .. ":slab_"  .. name)
 end
 
 -- farming registrations
@@ -78,7 +81,11 @@ if minetest.get_modpath("farming") then
 		local nodename = mod .. ":" .. name
 		local ndef = table.copy(minetest.registered_nodes[nodename])
 		ndef.sunlight_propagates = true
-		stairsplus:register_all("moreblocks", name, nodename, ndef)
+
+		mod = "moreblocks"
+		stairsplus:register_all(mod, name, nodename, ndef)
+		minetest.register_alias_force("stairs:stair_" .. name, mod .. ":stair_" .. name)
+		minetest.register_alias_force("stairs:slab_"  .. name, mod .. ":slab_"  .. name)
 	end
 end
 

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -101,7 +101,6 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 		end
 		minetest.register_node(":" .. modname .. ":slab_" .. subname .. alternate, def)
 	end
-	minetest.register_alias("stairs:slab_" .. subname, modname .. ":slab_" .. subname)
 
 	circular_saw.known_nodes[recipeitem] = {modname, subname}
 

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -141,7 +141,6 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 		end
 		minetest.register_node(":" .. modname .. ":stair_" .. subname .. alternate, def)
 	end
-	minetest.register_alias("stairs:stair_" .. subname, modname .. ":stair_" .. subname)
 
 	circular_saw.known_nodes[recipeitem] = {modname, subname}
 


### PR DESCRIPTION
Only make aliases automatically for stairs and slabs from MTG stairs mod. Let other mods worry about aliasing themselves.  Fixes minetest-mods/moreblocks#45