### PR TITLE
Readd tar block. Fixes #103

### DIFF
--- a/aliases.lua
+++ b/aliases.lua
@@ -62,7 +62,6 @@ minetest.register_alias("moreblocks:wood_tile_left","moreblocks:wood_tile_up")
 minetest.register_alias("moreblocks:wood_tile_right","moreblocks:wood_tile_up")
 minetest.register_alias("moreblocks:empty_bookshelf","moreblocks:empty_shelf")
 minetest.register_alias("moreblocks:split_stone_tile_alt","moreblocks:checker_stone_tile")
-minetest.register_alias("moreblocks:tar","default:gravel")
 
 -- ABM for horizontal trees (fix facedir):
 local horizontal_tree_convert_facedir = {7, 12, 9, 18}

--- a/crafting.lua
+++ b/crafting.lua
@@ -486,6 +486,10 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
+	type = "cooking", output = "moreblocks:tar", recipe = "default:pine_tree",
+})
+
+minetest.register_craft({
 	type = "shapeless",
 	output = "moreblocks:copperpatina",
 	recipe = {"group:water_bucket", "default:copperblock"},

--- a/nodes.lua
+++ b/nodes.lua
@@ -113,6 +113,12 @@ local nodes = {
 		is_ground_content = false,
 		sounds = sound_stone,
 	},
+	["tar"] = {
+		description = S("Tar"),
+		groups = {cracky=2, tar_block=1},
+		is_ground_content = false,
+		sounds = sound_stone,
+	},
 	["dirt_compressed"] = {
 		description = S("Compressed Dirt"),
 		groups = {crumbly=2},


### PR DESCRIPTION
~~This does not readd the crafting recipe for tar as the block may be removed again once #68 is resolved.~~

Closes #103

EDIT:
An improved recipe for `moreblock:tar` was added to resolve the conflict with `streetsmod`.