### PR TITLE
Finish aliasing split_stone_tile_alt

### DIFF
--- a/crafting.lua
+++ b/crafting.lua
@@ -171,7 +171,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "moreblocks:split_stone_tile_alt",
+	output = "moreblocks:checker_stone_tile",
 	recipe = {
 		{"moreblocks:split_stone_tile"},
 	}
@@ -181,7 +181,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "default:cobble",
 	recipe = {
-		{"moreblocks:split_stone_tile_alt"},
+		{"moreblocks:checker_stone_tile"},
 	}
 })
 

--- a/stairsplus/registrations.lua
+++ b/stairsplus/registrations.lua
@@ -107,3 +107,23 @@ if minetest.get_modpath("wool") then
 		stairsplus:register_all(mod, name, nodename, ndef)
 	end
 end
+
+-- Alias cuts of split_stone_tile_alt which was renamed checker_stone_tile.
+stairsplus:register_alias_all("moreblocks", "split_stone_tile_alt", "moreblocks", "checker_stone_tile")
+
+-- The following LBM is necessary because the name stair_split_stone_tile_alt
+-- conflicts with another node and so the alias for that specific node gets
+-- ignored.
+minetest.register_lbm({
+	name = "moreblocks:fix_split_stone_tile_alt_name_collision",
+	nodenames = {"moreblocks:stair_split_stone_tile_alt"},
+	action = function(pos, node)
+		minetest.set_node(pos, {
+			name = "moreblocks:stair_checker_stone_tile",
+			param2 = minetest.get_node(pos).param2
+
+		})
+		minetest.log('action', "LBM replaced " .. node.name ..
+			" at " .. minetest.pos_to_string(pos))
+	end,
+})


### PR DESCRIPTION
to checker_stone_tile.

Existing `moreblocks:stair_split_stone_tile_alt` blocks will change from the checkered looking version to the split stone appearance.
![screenshot_20171230_110953](https://user-images.githubusercontent.com/13209539/34455705-af413b64-ed52-11e7-97b3-07188c4ca54f.png)

This is unavoidable because force aliasing `moreblocks:stair_split_stone_tile_alt` to `moreblocks:stair_checker_stone_tile`, which would preserve existing builds, will also entirely prevent constructing `moreblocks:stair_split_stone_tile_alt`. This issue was originally identified in #87.