### PR TITLE
Conserve left-over microblocks.

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -154,16 +154,14 @@ function circular_saw:update_inventory(pos, amount)
 		return
 	end
 
+	-- Determine the kind of stairs from either the normal block or micro block.
 	local stack = inv:get_stack("input",  1)
-	-- At least one "normal" block is necessary to see what kind of stairs are requested.
+	local node_name = ""
 	if stack:is_empty() then
-		-- Any microblocks not taken out yet are now lost.
-		-- (covers material loss in the machine)
-		self:reset(pos)
-		return
-
+		node_name = inv:get_stack("micro", 1):get_name():gsub(":micro_", ":") or ""
+	else
+		node_name = stack:get_name() or ""
 	end
-	local node_name = stack:get_name() or ""
 	local name_parts = circular_saw.known_nodes[node_name] or ""
 	local modname  = name_parts[1] or ""
 	local material = name_parts[2] or ""


### PR DESCRIPTION
This commit conserves the microblocks so that they are never lost.  Previously, any left-over microblocks were destroyed if the input box was manually emptied or if anything was taken from the output while the input box is empty.  