### PR TITLE
Bug with `setting_getbool` and `register_alias_force` when trying to install

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -8,7 +8,7 @@ Licensed under the zlib license. See LICENSE.md for more information.
 moreblocks.config = {}
 
 local function getbool_default(setting, default)
-	local value = minetest.settings:get_bool(setting)
+	local value = minetest.setting_getbool(setting)
 	if value == nil then
 		value = default
 	end

--- a/stairsplus/init.lua
+++ b/stairsplus/init.lua
@@ -15,7 +15,7 @@ stairsplus.expect_infinite_stacks = false
 stairsplus.shapes_list = {}
 
 if not minetest.get_modpath("unified_inventory")
-and minetest.settings:get_bool("creative_mode") then
+and minetest.setting_getbool("creative_mode") then
 	stairsplus.expect_infinite_stacks = true
 end
 


### PR DESCRIPTION
I tried to install this mod. I first got a bug with `setting_getbool`. So I looked into https://minetest.org/modbook/lua_api.html#initlua and I hot fixed the bug in this PR.

But I still have another bug that trash at the beginning when starting my server:

```
Error from Lua:
...u/.minetest/mods/moreblocks/stairsplus/registrations.lua:73: attempt to call field 'register_alias_force' (a nil value)
stack traceback:
	...u/.minetest/mods/moreblocks/stairsplus/registrations.lua:73: in main chunk
	[C]: in function 'dofile'
	/home/ju/.minetest/mods/moreblocks/stairsplus/init.lua:93: in main chunk
	[C]: in function 'dofile'
	/home/ju/.minetest/mods/moreblocks/init.lua:29: in main chunk
Abandon (core dumped)
```

When looking into the mod API, it seems that it should works...

I have Minetest 0.4.13

To reproduce it, I just install this mod on a fresh install of Minetest 0.4.13, by `git clone` in `mods/` folder, then set `load_mod_moreblocks = true` in `world.mt`