### PR TITLE
Suppress alias warnings on stairsplus overrides.

### DIFF
--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -101,7 +101,7 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 		end
 		minetest.register_node(":" ..modname.. ":micro_" ..subname..alternate, def)
 	end
-	minetest.register_alias(modname.. ":micro_" ..subname.. "_bottom", modname.. ":micro_" ..subname)
+	minetest.register_alias_force(modname.. ":micro_" ..subname.. "_bottom", modname.. ":micro_" ..subname)
 
 	circular_saw.known_nodes[recipeitem] = {modname, subname}
 

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -101,7 +101,7 @@ function stairsplus:register_panel(modname, subname, recipeitem, fields)
 		end
 		minetest.register_node(":" ..modname.. ":panel_" ..subname..alternate, def)
 	end
-	minetest.register_alias(modname.. ":panel_" ..subname.. "_bottom", modname.. ":panel_" ..subname)
+	minetest.register_alias_force(modname.. ":panel_" ..subname.. "_bottom", modname.. ":panel_" ..subname)
 
 	circular_saw.known_nodes[recipeitem] = {modname, subname}
 


### PR DESCRIPTION
Overriding stairsplus nodes in other mods resulted in warnings like:

> WARNING[Main]: Not registering alias, item with same name is already defined: default:micro_ice_bottom -> default:micro_ice

This commit resolves the warnings by forcing the alias.