### PR TITLE
functional sweeper [WIP]

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -24,6 +24,19 @@ moreblocks.intllib = S
 
 local modpath = minetest.get_modpath("moreblocks")
 
+function moreblocks.check_protection(pos, name, tool, text)
+	if minetest.is_protected(pos, name) then
+		minetest.log("action", (name ~= "" and name or "A mod")
+			.. " tried to " .. text
+			.. " at protected position "
+			.. minetest.pos_to_string(pos)
+			.. " with a " .. (tool or ""))
+		minetest.record_protection_violation(pos, name)
+		return true
+	end
+	return false
+end
+
 dofile(modpath .. "/config.lua")
 dofile(modpath .. "/circular_saw.lua")
 dofile(modpath .. "/stairsplus/init.lua")
@@ -31,6 +44,7 @@ dofile(modpath .. "/nodes.lua")
 dofile(modpath .. "/redefinitions.lua")
 dofile(modpath .. "/crafting.lua")
 dofile(modpath .. "/aliases.lua")
+dofile(modpath .. "/sweeper.lua")
 
 if minetest.settings:get_bool("log_mods") then
 	minetest.log("action", S("[moreblocks] loaded."))

--- a/nodes.lua
+++ b/nodes.lua
@@ -472,10 +472,3 @@ for name, def in pairs(nodes) do
 		})
 	end
 end
-
--- Items
-
-minetest.register_craftitem("moreblocks:sweeper", {
-	description = S("Sweeper"),
-	inventory_image = "moreblocks_sweeper.png",
-})

--- a/sweeper.lua
+++ b/sweeper.lua
@@ -1,0 +1,45 @@
+local S = moreblocks.intllib
+local check_protection = moreblocks.check_protection
+local sweepables = {}
+
+-- example sweepable node
+-- TODO API for sweepable node registration
+sweepables["default:mossycobble"] = function(pos, node)
+	-- hit 3 times to clean
+	if node.param1 < 2 then
+		node.param1 = node.param1 + 1
+		minetest.set_node(pos, node)
+		return false
+	end
+
+	-- set clean node
+	minetest.set_node(pos, { name = "default:cobble" })
+
+	return true
+end
+
+
+-- functional sweeper
+minetest.register_craftitem("moreblocks:sweeper", {
+	description = S("Sweeper"),
+	inventory_image = "moreblocks_sweeper.png",
+	on_use = function(itemstack, user, pointed_thing)
+		if pointed_thing.type ~= "node" then
+			-- do nothing if it's not a node
+			return
+		end
+
+		local node = minetest.get_node(pointed_thing.under)
+		local sweepable = sweepables[node.name]
+
+		if not sweepable then
+			return
+		end
+
+		if check_protection(pointed_thing.under, user:get_player_name(), "sweeper", "sweep " .. node.name) then
+			return
+		end
+
+		sweepable(pointed_thing.under, node)
+	end
+})

--- a/sweeper.lua
+++ b/sweeper.lua
@@ -2,24 +2,9 @@ local S = moreblocks.intllib
 local check_protection = moreblocks.check_protection
 local sweepables = {}
 
--- example sweepable node
--- TODO API for sweepable node registration
-sweepables["default:mossycobble"] = function(pos, node)
-	-- hit 3 times to clean
-	if node.param1 < 2 then
-		node.param1 = node.param1 + 1
-		minetest.set_node(pos, node)
-		return false
-	end
-
-	-- set clean node
-	minetest.set_node(pos, { name = "default:cobble" })
-
-	return true
-end
-
-
+--
 -- functional sweeper
+--
 minetest.register_craftitem("moreblocks:sweeper", {
 	description = S("Sweeper"),
 	inventory_image = "moreblocks_sweeper.png",
@@ -30,16 +15,66 @@ minetest.register_craftitem("moreblocks:sweeper", {
 		end
 
 		local node = minetest.get_node(pointed_thing.under)
-		local sweepable = sweepables[node.name]
+		local ndef = minetest.registered_nodes[node.name]
+		local sweepable = sweepables[node.name] or (ndef and ndef.on_sweep)
 
 		if not sweepable then
 			return
 		end
 
-		if check_protection(pointed_thing.under, user:get_player_name(), "sweeper", "sweep " .. node.name) then
+		if check_protection(pointed_thing.under, user and user:get_player_name(), "sweeper", "sweep " .. node.name) then
 			return
 		end
 
 		sweepable(pointed_thing.under, node)
 	end
 })
+
+--
+-- register sweepable node handler
+--
+function moreblocks:register_sweepable(node_name, callback)
+	sweepables[node_name] = callback
+end
+
+
+
+------------------------------------
+-- DEMO CODE                      --
+-- TODO: REMOVE AFTER TESTING     --
+-- Sweepable mossycobble example: --
+
+-- use register_sweepable function
+moreblocks:register_sweepable("default:mossycobble", function (pos, node)
+	local meta = minetest.get_meta(pos)
+	local sweeps = meta:get_int('sweeps') + 1
+
+	-- hit 3 times to clean
+	if sweeps > 2 then
+		-- set clean node
+		meta:set_int('sweeps', 0)
+		minetest.swap_node(pos, { name = "default:cobble" })
+		return true
+	end
+
+	meta:set_int('sweeps', sweeps)
+
+	return false
+end)
+
+-- or when registering node
+--[[ 
+minetest.register_node("default:mossycobble", {
+	description = S("Mossy Cobblestone"),
+	tiles = {"default_mossycobble.png"},
+	is_ground_content = false,
+	groups = {cracky = 3, stone = 1},
+	sounds = default.node_sound_stone_defaults(),
+
+	on_sweep = function (pos, node)
+		-- do the magic here
+	end,
+})
+]]
+
+-------------------------------------


### PR DESCRIPTION
This is a proposal of how a sweeper could be made functional.

This PR has one example of `default:mossycobblestone` sweeping, after 3 sweeps it will become "clean" again, e.g. replaced by `default:cobble`.

![sweep-demo](https://user-images.githubusercontent.com/6502486/42719576-21f1b594-8718-11e8-9975-1c4224beb382.gif)

is this a useful feature?

In future one might add API for registering "sweepable" nodes, with custom or default logic.
