### PR TITLE
Fix double definition of paper from papyrus

### DIFF
--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -25,7 +25,11 @@ minetest.register_craft({
 	}
 })
 
-minetest.clear_craft({recipe = {{"default:papyrus", "default:papyrus", "default:papyrus"}}})
+minetest.clear_craft({
+	recipe = {
+		{"default:papyrus", "default:papyrus", "default:papyrus"}
+	}
+})
 minetest.register_craft({
 	output = "default:paper 4",
 	recipe = {

--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -25,6 +25,7 @@ minetest.register_craft({
 	}
 })
 
+minetest.clear_craft({recipe = {{"default:papyrus", "default:papyrus", "default:papyrus"}}})
 minetest.register_craft({
 	output = "default:paper 4",
 	recipe = {


### PR DESCRIPTION
Currently, there is a definition conflict for paper from three papyrus, and `default` wins, making this mod's definition redundant.