### PR TITLE
Fix node rotation (#123)

### DIFF
--- a/stairsplus/common.lua
+++ b/stairsplus/common.lua
@@ -30,6 +30,7 @@ stairsplus.register_single = function(category, alternate, info, modname, subnam
 	end
 	def.paramtype = "light"
 	def.paramtype2 = def.paramtype2 or "facedir"
+	def.place_param2 = nil
 	def.on_place = minetest.rotate_node
 	if category ~= "slab" then
 		def.description = S("%s " .. descriptions[category]):format(fields.description)


### PR DESCRIPTION
Fix node rotation when source node is defined with place_param2 property settled to 0. (#123)
However, this fix disable the global world texture orientation for fixed nodes in minetest 0.5-dev