### PR TITLE
fix wood_tile_center craft

### DIFF
--- a/crafting.lua
+++ b/crafting.lua
@@ -36,6 +36,15 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
+	output = "moreblocks:wood_tile_center 9",
+	recipe = {
+		{"group:wood", "group:wood", "group:wood"},
+		{"group:wood", "moreblocks:wood_tile", "group:wood"},
+		{"group:wood", "group:wood", "group:wood"},
+	}
+})
+
+minetest.register_craft({
 	output = "moreblocks:wood_tile 9",
 	recipe = {
 		{"group:wood", "group:wood", "group:wood"},
@@ -48,15 +57,6 @@ minetest.register_craft({
 	type = "shapeless",
 	output = "moreblocks:wood_tile",
 	recipe = {"moreblocks:wood_tile_flipped"}
-})
-
-minetest.register_craft({
-	output = "moreblocks:wood_tile_center 9",
-	recipe = {
-		{"group:wood", "group:wood", "group:wood"},
-		{"group:wood", "moreblocks:wood_tile", "group:wood"},
-		{"group:wood", "group:wood", "group:wood"},
-	}
 })
 
 minetest.register_craft({


### PR DESCRIPTION
The recipe for **wood_tile_center** needs to be put before **wood_tile** for it to work properly since all tiles are considered group:wood and it automatically crafts a normal wooden tile instead of the centered one.