### PR TITLE
Refresh built-in crafting recipe overrides

### DIFF
--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -7,14 +7,41 @@ Licensed under the zlib license. See LICENSE.md for more information.
 
 -- Redefinitions of some default crafting recipes:
 
-minetest.register_craft({
-	output = "default:sign_wall 4",
+-- Signs: +1
+minetest.clear_craft({
 	recipe = {
-		{"default:wood", "default:wood", "default:wood"},
-		{"default:wood", "default:wood", "default:wood"},
-		{"", "default:stick", ""},
+		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{'', 'group:stick', ''},
 	}
 })
+
+minetest.clear_craft({
+	recipe = {
+		{'group:wood', 'group:wood', 'group:wood'},
+		{'group:wood', 'group:wood', 'group:wood'},
+		{'', 'group:stick', ''},
+	}
+})
+
+minetest.register_craft({
+	output = 'default:sign_wall_steel 4',
+	recipe = {
+		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{'', 'group:stick', ''},
+	}
+})
+
+minetest.register_craft({
+	output = 'default:sign_wall_wood 4',
+	recipe = {
+		{'group:wood', 'group:wood', 'group:wood'},
+		{'group:wood', 'group:wood', 'group:wood'},
+		{'', 'group:stick', ''},
+	}
+})
+
 
 minetest.clear_craft({
 	recipe = {
@@ -27,6 +54,7 @@ minetest.register_craft({
 		{"default:papyrus", "default:papyrus", "default:papyrus"},
 	}
 })
+
 
 minetest.register_craft({
 	output = "default:rail 24",

--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -16,15 +16,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "default:ladder 4",
-	recipe = {
-		{"default:stick", "", "default:stick"},
-		{"default:stick", "default:stick", "default:stick"},
-		{"default:stick", "", "default:stick"},
-	}
-})
-
 minetest.clear_craft({
 	recipe = {
 		{"default:papyrus", "default:papyrus", "default:papyrus"}


### PR DESCRIPTION
Some commits to refresh some of the recipe overrides: the ladder one gets removed (we're behind MTG 5 otherwise). The sign recipes got updated and are now for both wood and steel signs. The rail recipe should be updated too, but the new ones in MTG 5 are considerably different, so I'm not sure what our policy with this should be.