### PR TITLE
Realign the rail craft recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor recipe override mechanism to avoid re-coding recipes
+  when we only want to change the amount produced.
+- Realign rail recipe to the changes made in Minetest Game. All rail recipes
+  (standard, power, break) are boosted by 50%.
+
 ### Fixed
 
 - [Fixed strange placement behavior for non-default Stairs+ nodes.](https://github.com/minetest-mods/moreblocks/pull/168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Refactored recipe override mechanism to avoid re-coding recipes
   when we only want to change the amount produced.
-- Realigned rail recipe to the changes made in Minetest Game. All rail recipes
-  (standard, power, break) were boosted by 50%.
+- [Realigned rail recipe to the changes made in Minetest Game.](https://github.com/minetest-mods/moreblocks/pull/169)
+  - All rail recipes (standard, power, break) were boosted by 50%.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Refactor recipe override mechanism to avoid re-coding recipes
+- Refactored recipe override mechanism to avoid re-coding recipes
   when we only want to change the amount produced.
-- Realign rail recipe to the changes made in Minetest Game. All rail recipes
-  (standard, power, break) are boosted by 50%.
+- Realigned rail recipe to the changes made in Minetest Game. All rail recipes
+  (standard, power, break) were boosted by 50%.
 
 ### Fixed
 

--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -5,6 +5,8 @@ Copyright © 2011-2020 Hugo Locurcio and contributors.
 Licensed under the zlib license. See LICENSE.md for more information.
 --]]
 
+local modname = minetest.get_current_modname()
+
 -- Redefine some of the default crafting recipes to be more productive
 
 -- Auxiliary function: take a recipe as returned by get_all_craft_recipes
@@ -39,14 +41,13 @@ local change_recipe_amount = function(product, recipe, func)
 	redo.output = ("%s %d"):format(product, newamount)
 	minetest.register_craft(redo)
 
-	minetest.log(("moreblocks recipe for %s production: %d => %d"):format(product, oldamount, newamount))
+	minetest.log("action", ("[MOD]%s: recipe for %s production: %d => %d"):format(modname, product, oldamount, newamount))
 end
 
 local increase_craft_production = function(product, func)
 	local recipes = minetest.get_all_craft_recipes(product)
 	for _, r in pairs(recipes) do
 		if r.type == "normal" or r.method == "normal" then
-			minetest.log(dump(r))
 			change_recipe_amount(product, r, func)
 		end
 	end

--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -72,41 +72,9 @@ local increase_craft_production_table = function(map_table)
 	end
 end
 
--- Signs: +1
-minetest.clear_craft({
-	recipe = {
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
-		{'', 'group:stick', ''},
-	}
+increase_craft_production_table({
+	{ function(n) return n:match('^default:sign_wall') end, function(old) return old + 1 end },
 })
-
-minetest.clear_craft({
-	recipe = {
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'', 'group:stick', ''},
-	}
-})
-
-minetest.register_craft({
-	output = 'default:sign_wall_steel 4',
-	recipe = {
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
-		{'', 'group:stick', ''},
-	}
-})
-
-minetest.register_craft({
-	output = 'default:sign_wall_wood 4',
-	recipe = {
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'', 'group:stick', ''},
-	}
-})
-
 
 minetest.clear_craft({
 	recipe = {

--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -74,20 +74,8 @@ end
 
 increase_craft_production_table({
 	{ function(n) return n:match('^default:sign_wall') end, function(old) return old + 1 end },
+	{ function(n) return n == 'default:paper' end, function(old) return old*4 end },
 })
-
-minetest.clear_craft({
-	recipe = {
-		{"default:papyrus", "default:papyrus", "default:papyrus"}
-	}
-})
-minetest.register_craft({
-	output = "default:paper 4",
-	recipe = {
-		{"default:papyrus", "default:papyrus", "default:papyrus"},
-	}
-})
-
 
 minetest.register_craft({
 	output = "default:rail 24",

--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -5,7 +5,72 @@ Copyright © 2011-2020 Hugo Locurcio and contributors.
 Licensed under the zlib license. See LICENSE.md for more information.
 --]]
 
--- Redefinitions of some default crafting recipes:
+-- Redefine some of the default crafting recipes to be more productive
+
+-- Auxiliary function: take a recipe as returned by get_all_craft_recipes
+-- and turn it into a table that can be used to clear a craft or declare a new one
+local reconstruct_internal_craft = function(recipe)
+	local recp = {
+		{ "", "", "" },
+		{ "", "", "" },
+		{ "", "", "" },
+	}
+	for idx, item in pairs(recipe.items) do
+		local row = math.ceil(idx / recipe.width)
+		local col = idx - (row-1)*recipe.width
+		recp[row][col] = item
+	end
+	return recp
+end
+
+-- Change the amount produced by recipe by apply func to the old amount
+local change_recipe_amount = function(product, recipe, func)
+	local recp = reconstruct_internal_craft(recipe)
+
+	local oldamount = tonumber(recipe.output:match(" [0-9]+$") or "1")
+
+	local newamount = func(oldamount)
+
+	-- remove old crafting recipe
+	local redo = { recipe = recp }
+	minetest.clear_craft(redo)
+
+	-- new output
+	redo.output = ("%s %d"):format(product, newamount)
+	minetest.register_craft(redo)
+
+	minetest.log(("moreblocks recipe for %s production: %d => %d"):format(product, oldamount, newamount))
+end
+
+local increase_craft_production = function(product, func)
+	local recipes = minetest.get_all_craft_recipes(product)
+	for _, r in pairs(recipes) do
+		if r.type == "normal" or r.method == "normal" then
+			minetest.log(dump(r))
+			change_recipe_amount(product, r, func)
+		end
+	end
+end
+
+-- Increase the crafting production according to the rules from the table, which is in the form:
+-- {
+--   { detector, amount changing function }
+--   { detector, amount changing function }
+-- }
+-- TODO: consider exporting this function to other mods
+local increase_craft_production_table = function(map_table)
+	for product, _ in pairs(minetest.registered_items) do
+		for _, tab in pairs(map_table) do
+			local detector = tab[1]
+			local func = tab[2]
+			if detector(product) then
+				increase_craft_production(product, func)
+				-- only apply one boost
+				break
+			end
+		end
+	end
+end
 
 -- Signs: +1
 minetest.clear_craft({

--- a/redefinitions.lua
+++ b/redefinitions.lua
@@ -75,15 +75,7 @@ end
 increase_craft_production_table({
 	{ function(n) return n:match('^default:sign_wall') end, function(old) return old + 1 end },
 	{ function(n) return n == 'default:paper' end, function(old) return old*4 end },
-})
-
-minetest.register_craft({
-	output = "default:rail 24",
-	recipe = {
-		{"default:steel_ingot", "", "default:steel_ingot"},
-		{"default:steel_ingot", "default:stick", "default:steel_ingot"},
-		{"default:steel_ingot", "", "default:steel_ingot"},
-	}
+	{ function(n) return n:match('^carts:.*rail$') or n:match('^default:.*rail$') end, function(old) return old + old/2 end },
 })
 
 minetest.register_craft({


### PR DESCRIPTION
This replaces the override for the obsolete rail recipe with an override
for the new recipes for all rail types. Rather than hard-coding the
recipes, we “reconstruct” the declared crafting recipes and simply pump
up the amount produced by 50% (which was the increase achieved over the
old recipe).

Fixes #162.