### PR TITLE
Fix dupe bug

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -336,6 +336,7 @@ function circular_saw.on_metadata_inventory_take(
 	local input_stack = inv:get_stack(listname,  index)
 	if not input_stack:is_empty() and input_stack:get_name()~=stack:get_name() then
 		local player_inv = player:get_inventory()
+		inv:remove_item(listname, input_stack)
 		if player_inv:room_for_item("main", input_stack) then
 			player_inv:add_item("main", input_stack)
 		end

--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -336,7 +336,10 @@ function circular_saw.on_metadata_inventory_take(
 	local input_stack = inv:get_stack(listname,  index)
 	if not input_stack:is_empty() and input_stack:get_name()~=stack:get_name() then
 		local player_inv = player:get_inventory()
+
+		-- Prevent arbitrary item duplication.
 		inv:remove_item(listname, input_stack)
+		
 		if player_inv:room_for_item("main", input_stack) then
 			player_inv:add_item("main", input_stack)
 		end

--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -339,7 +339,7 @@ function circular_saw.on_metadata_inventory_take(
 
 		-- Prevent arbitrary item duplication.
 		inv:remove_item(listname, input_stack)
-		
+
 		if player_inv:room_for_item("main", input_stack) then
 			player_inv:add_item("main", input_stack)
 		end


### PR DESCRIPTION
Swapping items into the circular saw's inventory under certain circumstances allows for duplication of arbitrary itemstacks. This should fix that problem.