### PR TITLE
Resolve aliases in cost calculation

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -89,8 +89,9 @@ circular_saw.names = {
 }
 
 function circular_saw:get_cost(inv, stackname)
+	local name = minetest.registered_aliases[stackname] or stackname
 	for i, item in pairs(inv:get_list("output")) do
-		if item:get_name() == stackname then
+		if item:get_name() == name then
 			return circular_saw.cost_in_microblocks[i]
 		end
 	end


### PR DESCRIPTION
Fixes #174.

If stairs from stairs mod were crafted before moreblocks was enabled, the old (now aliased) stairs variant is kept in inventory. If the player tried to recycle that stair variant, `inv:contains_item("output", stackname)` would return true as `contains_item` resolves alias names, but `circular_saw:get_cost` would return nil as it's expecting exact `stackname` matches which would later crash due to nil arithmetic.

This PR fixes this issue by resolving alias using `minetest.registered_aliases` table.
`circular_saw:get_cost` should work now in every scenario where `inv:contains_item("output", stackname)` returns true.
