### PR TITLE
opt-depend on default mod

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -363,9 +363,15 @@ function circular_saw.on_metadata_inventory_take(
 	-- The recycle field plays no role here since it is processed immediately.
 end
 
+local has_default_mod = minetest.get_modpath("default")
+
 function circular_saw.on_construct(pos)
 	local meta = minetest.get_meta(pos)
-	local fancy_inv = default.gui_bg..default.gui_bg_img..default.gui_slots
+	local fancy_inv = ""
+	if has_default_mod then
+		-- prepend background and slot styles from default if available
+		fancy_inv = default.gui_bg..default.gui_bg_img..default.gui_slots
+	end
 	meta:set_string(
 		"formspec", "size[11,10]"..fancy_inv..
 		"label[0,0;" ..F(S("Input\nmaterial")).. "]" ..
@@ -437,7 +443,7 @@ minetest.register_node("moreblocks:circular_saw",  {
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy = 2,oddly_breakable_by_hand = 2},
-	sounds = default.node_sound_wood_defaults(),
+	sounds = moreblocks.node_sound_wood_defaults(),
 	on_construct = circular_saw.on_construct,
 	can_dig = circular_saw.can_dig,
 	-- Set the owner of this circular saw.

--- a/init.lua
+++ b/init.lua
@@ -17,9 +17,13 @@ moreblocks.S = S
 moreblocks.NS = NS
 
 dofile(modpath .. "/config.lua")
+dofile(modpath .. "/sounds.lua")
 dofile(modpath .. "/circular_saw.lua")
 dofile(modpath .. "/stairsplus/init.lua")
-dofile(modpath .. "/nodes.lua")
-dofile(modpath .. "/redefinitions.lua")
-dofile(modpath .. "/crafting.lua")
-dofile(modpath .. "/aliases.lua")
+
+if minetest.get_modpath("default") then
+    dofile(modpath .. "/nodes.lua")
+    dofile(modpath .. "/redefinitions.lua")
+    dofile(modpath .. "/crafting.lua")
+    dofile(modpath .. "/aliases.lua")
+end

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,4 @@
 name = moreblocks
 description = Adds various miscellaneous blocks to the game.
-depends = default
-optional_depends = intllib,stairs,farming,wool,basic_materials
+optional_depends = default,intllib,stairs,farming,wool,basic_materials
 min_minetest_version = 5.0.0

--- a/nodes.lua
+++ b/nodes.lua
@@ -7,15 +7,15 @@ Licensed under the zlib license. See LICENSE.md for more information.
 
 local S = moreblocks.S
 
-local sound_dirt = default.node_sound_dirt_defaults()
-local sound_wood = default.node_sound_wood_defaults()
-local sound_stone = default.node_sound_stone_defaults()
-local sound_glass = default.node_sound_glass_defaults()
-local sound_leaves = default.node_sound_leaves_defaults()
+local sound_dirt = moreblocks.node_sound_dirt_defaults()
+local sound_wood = moreblocks.node_sound_wood_defaults()
+local sound_stone = moreblocks.node_sound_stone_defaults()
+local sound_glass = moreblocks.node_sound_glass_defaults()
+local sound_leaves = moreblocks.node_sound_leaves_defaults()
 
 -- Don't break on 0.4.14 and earlier.
-local sound_metal = (default.node_sound_metal_defaults
-		and default.node_sound_metal_defaults() or sound_stone)
+local sound_metal = (moreblocks.node_sound_metal_defaults
+		and moreblocks.node_sound_metal_defaults() or sound_stone)
 
 local function tile_tiles(name)
 	local tex = "moreblocks_" ..name.. ".png"

--- a/sounds.lua
+++ b/sounds.lua
@@ -1,0 +1,48 @@
+--[[
+More Blocks: sound definitions
+
+Copyright © 2011-2020 Hugo Locurcio and contributors.
+Licensed under the zlib license. See LICENSE.md for more information.
+--]]
+
+function moreblocks.node_sound_wood_defaults()
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_wood_defaults()
+    end
+end
+
+function moreblocks.node_sound_glass_defaults()
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_glass_defaults()
+    end
+end
+
+function moreblocks.node_sound_metal_defaults()
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_metal_defaults()
+    end
+end
+
+function moreblocks.node_sound_stone_defaults()
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_stone_defaults()
+    end
+end
+
+function moreblocks.node_sound_dirt_defaults()
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_dirt_defaults()
+    end
+end
+
+function moreblocks.node_sound_leaves_defaults()
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_leaves_defaults()
+    end
+end

--- a/stairsplus/API.md
+++ b/stairsplus/API.md
@@ -10,7 +10,7 @@
 		description = "Wooden",
 		tiles = {"default_wood.png"},
 		groups = {oddly_breakabe_by_hand=1},
-		sounds = default.node_sound_wood_defaults(),
+		sounds = moreblocks.node_sound_wood_defaults(),
 	})
 	```
 The following register only a particular type of microblock.

--- a/stairsplus/custom.lua
+++ b/stairsplus/custom.lua
@@ -69,7 +69,7 @@ local function register_custom_subset(subset, modname, subname, recipeitem, grou
 		description = description,
 		drop = drop,
 		light_source = light,
-		sounds = default.node_sound_stone_defaults(),
+		sounds = moreblocks.node_sound_stone_defaults(),
 	})
 end
 

--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -15,7 +15,7 @@ local function register_micro(modname, subname, recipeitem, groups, images, desc
 		description = description,
 		drop = drop,
 		light_source = light,
-		sounds = default.node_sound_stone_defaults(),
+		sounds = moreblocks.node_sound_stone_defaults(),
 	})
 end
 

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -15,7 +15,7 @@ local function register_panel(modname, subname, recipeitem, groups, images, desc
 		description = description,
 		drop = drop,
 		light_source = light,
-		sounds = default.node_sound_stone_defaults(),
+		sounds = moreblocks.node_sound_stone_defaults(),
 	})
 end
 

--- a/stairsplus/registrations.lua
+++ b/stairsplus/registrations.lua
@@ -6,75 +6,77 @@ Licensed under the zlib license. See LICENSE.md for more information.
 --]]
 
 -- default registrations
-local default_nodes = { -- Default stairs/slabs/panels/microblocks:
-	"stone",
-	"stone_block",
-	"cobble",
-	"mossycobble",
-	"brick",
-	"sandstone",
-	"steelblock",
-	"goldblock",
-	"copperblock",
-	"bronzeblock",
-	"diamondblock",
-	"tinblock",
-	"desert_stone",
-	"desert_stone_block",
-	"desert_cobble",
-	"meselamp",
-	"glass",
-	"tree",
-	"wood",
-	"jungletree",
-	"junglewood",
-	"pine_tree",
-	"pine_wood",
-	"acacia_tree",
-	"acacia_wood",
-	"aspen_tree",
-	"aspen_wood",
-	"obsidian",
-	"obsidian_block",
-	"obsidianbrick",
-	"obsidian_glass",
-	"stonebrick",
-	"desert_stonebrick",
-	"sandstonebrick",
-	"silver_sandstone",
-	"silver_sandstone_brick",
-	"silver_sandstone_block",
-	"desert_sandstone",
-	"desert_sandstone_brick",
-	"desert_sandstone_block",
-	"sandstone_block",
-	"coral_skeleton",
-	"ice",
-}
+if minetest.get_modpath("default") then
+	local default_nodes = { -- Default stairs/slabs/panels/microblocks:
+		"stone",
+		"stone_block",
+		"cobble",
+		"mossycobble",
+		"brick",
+		"sandstone",
+		"steelblock",
+		"goldblock",
+		"copperblock",
+		"bronzeblock",
+		"diamondblock",
+		"tinblock",
+		"desert_stone",
+		"desert_stone_block",
+		"desert_cobble",
+		"meselamp",
+		"glass",
+		"tree",
+		"wood",
+		"jungletree",
+		"junglewood",
+		"pine_tree",
+		"pine_wood",
+		"acacia_tree",
+		"acacia_wood",
+		"aspen_tree",
+		"aspen_wood",
+		"obsidian",
+		"obsidian_block",
+		"obsidianbrick",
+		"obsidian_glass",
+		"stonebrick",
+		"desert_stonebrick",
+		"sandstonebrick",
+		"silver_sandstone",
+		"silver_sandstone_brick",
+		"silver_sandstone_block",
+		"desert_sandstone",
+		"desert_sandstone_brick",
+		"desert_sandstone_block",
+		"sandstone_block",
+		"coral_skeleton",
+		"ice",
+	}
 
-for _, name in pairs(default_nodes) do
-	local mod = "default"
-	local nodename = mod .. ":" .. name
-	local ndef = table.copy(minetest.registered_nodes[nodename])
-	ndef.sunlight_propagates = true
+	for _, name in pairs(default_nodes) do
+		local mod = "default"
+		local nodename = mod .. ":" .. name
+		local ndef = table.copy(minetest.registered_nodes[nodename])
+		ndef.sunlight_propagates = true
 
-	-- Stone and desert_stone drop cobble and desert_cobble respectively.
-	if type(ndef.drop) == "string" then
-		ndef.drop = ndef.drop:gsub(".+:", "")
+		-- Stone and desert_stone drop cobble and desert_cobble respectively.
+		if type(ndef.drop) == "string" then
+			ndef.drop = ndef.drop:gsub(".+:", "")
+		end
+
+		-- Use the primary tile for all sides of cut glasslike nodes and disregard paramtype2.
+		if #ndef.tiles > 1 and ndef.drawtype and ndef.drawtype:find("glass") then
+			ndef.tiles = {ndef.tiles[1]}
+			ndef.paramtype2 = nil
+		end
+
+		mod = "moreblocks"
+		stairsplus:register_all(mod, name, nodename, ndef)
+		minetest.register_alias_force("stairs:stair_" .. name, mod .. ":stair_" .. name)
+		minetest.register_alias_force("stairs:stair_outer_" .. name, mod .. ":stair_" .. name .. "_outer")
+		minetest.register_alias_force("stairs:stair_inner_" .. name, mod .. ":stair_" .. name .. "_inner")
+		minetest.register_alias_force("stairs:slab_"  .. name, mod .. ":slab_"  .. name)
 	end
-
-	-- Use the primary tile for all sides of cut glasslike nodes and disregard paramtype2.
-	if #ndef.tiles > 1 and ndef.drawtype and ndef.drawtype:find("glass") then
-		ndef.tiles = {ndef.tiles[1]}
-		ndef.paramtype2 = nil
-	end
-
-	mod = "moreblocks"
-	stairsplus:register_all(mod, name, nodename, ndef)
-	minetest.register_alias_force("stairs:stair_" .. name, mod .. ":stair_" .. name)
-	minetest.register_alias_force("stairs:stair_outer_" .. name, mod .. ":stair_" .. name .. "_outer")
-	minetest.register_alias_force("stairs:stair_inner_" .. name, mod .. ":stair_" .. name .. "_inner")
-	minetest.register_alias_force("stairs:slab_"  .. name, mod .. ":slab_"  .. name)
 end
 
 -- farming registrations
@@ -118,7 +120,7 @@ if minetest.get_modpath("basic_materials") then
 		description = "Concrete",
 		tiles = {"basic_materials_concrete_block.png",},
 		groups = {cracky=1, level=2, concrete=1},
-		sounds = default.node_sound_stone_defaults(),
+		sounds = moreblocks.node_sound_stone_defaults(),
 	})
 
 	minetest.register_alias("prefab:concrete_stair","technic:stair_concrete")
@@ -128,7 +130,7 @@ if minetest.get_modpath("basic_materials") then
 		description = "Cement",
 		tiles = {"basic_materials_cement_block.png"},
 		groups = {cracky=2, not_in_creative_inventory=1},
-		sounds = default.node_sound_stone_defaults(),
+		sounds = moreblocks.node_sound_stone_defaults(),
 		sunlight_propagates = true,
 	})
 

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -15,7 +15,7 @@ local function register_slab(modname, subname, recipeitem, groups, images, descr
 		description = description,
 		drop = drop,
 		light_source = light,
-		sounds = default.node_sound_stone_defaults(),
+		sounds = moreblocks.node_sound_stone_defaults(),
 	})
 end
 

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -15,7 +15,7 @@ local function register_slope(modname, subname, recipeitem, groups, images, desc
 		description = description,
 		drop = drop,
 		light_source = light,
-		sounds = default.node_sound_stone_defaults(),
+		sounds = moreblocks.node_sound_stone_defaults(),
 	})
 end
 

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -15,7 +15,7 @@ local function register_stair(modname, subname, recipeitem, groups, images, desc
 		description = description,
 		drop = drop,
 		light_source = light,
-		sounds = default.node_sound_stone_defaults(),
+		sounds = moreblocks.node_sound_stone_defaults(),
 	})
 end
 


### PR DESCRIPTION
fixes #181

No new features/fixes, just fallbacks in case the `default` mod is not found

# How to test

Test-mod for use in the `devtest` game:

mod.conf
```
depends = moreblocks,basenodes
```

init.lua
```lua
local ndef = minetest.registered_nodes["basenodes:stone"]
stairsplus:register_all("basenodes", "stone", "basenodes:stone", {
    tiles = ndef.tiles,
    groups = ndef.groups
})
```

![screenshot_20210816_211524](https://user-images.githubusercontent.com/39065740/129618130-aaf7fcee-0c73-4498-978d-99a0b0a1d412.png)
