### PR TITLE
amend load print

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -25,3 +25,6 @@ if minetest.get_modpath("default") then
     dofile(modpath .. "/crafting.lua")
     dofile(modpath .. "/aliases.lua")
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] MoreOres loaded")


### PR DESCRIPTION
Add a final **print to log** at the end of `init.lua` to indicate the mod was loaded successfully. This idea was derived from other mods which are specifically aimed at MT servers.

This could be useful not only for player support (e.g. in the MT forum) but would certainly be useful for MT server admins using the CLI and reading their server logs.