### PR TITLE
[no sq] Fix furnace_burntime deprecation warning + placement error

### DIFF
--- a/nodes.lua
+++ b/nodes.lua
@@ -496,8 +496,21 @@ local nodes = {
 for name, def in pairs(nodes) do
 	def.is_ground_content = def.is_ground_content == true
 	def.tiles = def.tiles or {"moreblocks_" ..name.. ".png"}
+
+	local burntime = def.furnace_burntime
+	def.furnace_burntime = nil -- deprecated node def field
+
 	minetest.register_node("moreblocks:" ..name, def)
 	minetest.register_alias(name, "moreblocks:" ..name)
+
+	-- Optional: register the node as fuel
+	if burntime then
+		core.register_craft({
+			type = "fuel",
+			recipe = "moreblocks:" .. name,
+			burntime = burntime,
+		})
+	end
 
 	local tiles = def.tiles
 

--- a/stairsplus/common.lua
+++ b/stairsplus/common.lua
@@ -66,7 +66,10 @@ stairsplus.rotate_node_aux = function(itemstack, placer, pointed_thing)
 	local wallmounted = minetest.dir_to_wallmounted(vector.subtract(pointed_thing.above, under))
 
 	if same_cat and not aux then
-		p2 = under_node.param2
+		-- param2 can be in the range [0, 31]. We assume that the stair nodes use the
+		-- drawtype "facedir". Wrap the value like done in Luanti `src/mapnode.cpp`.
+		p2 = under_node.param2 % 24
+
 		-- flip if placing above or below an upright or upside-down node
 		-- TODO should we also flip when placing next to a side-mounted node?
 		if wallmounted < 2 then


### PR DESCRIPTION
Fixes deprecation warnings regarding `furnace_burntime`.
Fixes #201 

**How to test commit 2:**
```Lua
local my_param1, my_param2

core.register_tool("lab:override", {
    description = "Use=Set1/2, Place=increase param2 by 1",
    inventory_image = "server_view_mods.png",
	on_use = function(itemstack, user, pointed_thing)
		local pos = pointed_thing.under
		local n = core.get_node(pos)
		n.param1 = my_param1 or n.param1
		n.param2 = my_param2 or n.param2
		core.swap_node(pos, n)
	end,
	on_place = function(itemstack, placer, pointed_thing)
		local pos = pointed_thing.under
		local n = core.get_node(pos)
		n.param2 = n.param2 + 1
		core.swap_node(pos, n)
	end,
})

core.register_chatcommand("p1", {
	func = function(_, param)
		my_param1 = tonumber(param)
		return true, "Set param1 = " .. (my_param1 or "(keep unchanged)")
	end
})

core.register_chatcommand("p2", {
	func = function(_, param)
		my_param2 = tonumber(param)
		return true, "Set param2 = " .. (my_param2 or "(keep unchanged)")
	end
})
```

Punch a stair node after `/p2 24` and another after `/p2 1`. Both must look identical. No error is raised when placing another stair onto them.